### PR TITLE
No non-stdlib runtime dependencies

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,15 +4,16 @@ authors = ["Keno Fischer", "Dilum Aluthge", "contributors"]
 version = "1.0.0-DEV"
 
 [deps]
-DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 
 [compat]
-DocStringExtensions = "0.8.4"
 julia = "1.6"
 
 [extras]
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Pkg", "Test", "TOML"]

--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,6 @@ version = "1.0.0-DEV"
 
 [deps]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
-TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 
 [compat]
 julia = "1.6"

--- a/src/Docker.jl
+++ b/src/Docker.jl
@@ -1,7 +1,6 @@
 module Docker
 
 import Base: run, success
-import DocStringExtensions
 import Random
 
 export DockerConfig

--- a/src/container.jl
+++ b/src/container.jl
@@ -77,32 +77,32 @@ function build_docker_image(config::DockerConfig)
             open("Dockerfile", "w") do io
                 println(io, strip(dockerfile))
             end
-            if config.stdout_docker_build === nothing
+            if config.docker_build_stdout === nothing
                 if config.verbose
-                    stdout_docker_build = Base.stdout
+                    docker_build_stdout = Base.stdout
                 else
-                    stdout_docker_build = Base.devnull
+                    docker_build_stdout = Base.devnull
                 end
             else
-                stdout_docker_build = config.stdout_docker_build
+                docker_build_stdout = config.docker_build_stdout
             end
-            if config.stderr_docker_build === nothing
+            if config.docker_build_stderr === nothing
                 if config.verbose
-                    stderr_docker_build = Base.stderr
+                    docker_build_stderr = Base.stderr
                 else
-                    stderr_docker_build = Base.devnull
+                    docker_build_stderr = Base.devnull
                 end
             else
-                stderr_docker_build = config.stderr_docker_build
+                docker_build_stderr = config.docker_build_stderr
             end
-            (stdout_docker_build isa IO) || throw(ArgumentError("stdout_docker_build must be an IO"))
-            (stderr_docker_build isa IO) || throw(ArgumentError("stderr_docker_build must be an IO"))
+            (docker_build_stdout isa IO) || throw(ArgumentError("docker_build_stdout must be an IO"))
+            (docker_build_stderr isa IO) || throw(ArgumentError("docker_build_stderr must be an IO"))
             run(
                 pipeline(
                     `docker build -t $(docker_image) .`;
                     stdin = Base.devnull,
-                    stdout = stdout_docker_build,
-                    stderr = stderr_docker_build,
+                    stdout = docker_build_stdout,
+                    stderr = docker_build_stderr,
                 )
             )
         end

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,28 +1,37 @@
 """
-$(DocStringExtensions.TYPEDEF)
+    DockerConfig(; kwargs...)
 
-## Fields:
-$(DocStringExtensions.TYPEDFIELDS )
+## Required Keyword Arguments:
+- `image::String`
+
+## Optional Keyword Arguments:
+- `verbose::Bool = false`
+- `env::Dict{String, String} = Dict{String, String}()`
+- `platform::Symbol = :linux`
+- `read_only_maps::Dict{String, String} = Dict{String, String}()`
+- `read_write_maps::Dict{String, String} = Dict{String, String}()`
+- `stdin::IO = Base.devnull`
+- `stdout::IO = Base.stdout`
+- `stderr::IO = Base.stderr`
+- `docker_build_stdout::Union{IO, Nothing} = nothing`
+- `docker_build_stderr::Union{IO, Nothing} = nothing`
 """
 Base.@kwdef struct DockerConfig
     image::String
-    verbose::Bool                           = false
-    env::Dict{String, String}               = Dict{String, String}()
-    platform::Symbol                        = :linux
-    read_only_maps::Dict{String, String}    = Dict{String, String}()
-    read_write_maps::Dict{String, String}   = Dict{String, String}()
-    stdin::IO                               = Base.devnull
-    stdout::IO                              = Base.stdout
-    stderr::IO                              = Base.stderr
-    stdout_docker_build::Union{IO, Nothing} = nothing
-    stderr_docker_build::Union{IO, Nothing} = nothing
+    verbose::Bool = false
+    env::Dict{String, String} = Dict{String, String}()
+    platform::Symbol = :linux
+    read_only_maps::Dict{String, String} = Dict{String, String}()
+    read_write_maps::Dict{String, String} = Dict{String, String}()
+    stdin::IO = Base.devnull
+    stdout::IO = Base.stdout
+    stderr::IO = Base.stderr
+    docker_build_stdout::Union{IO, Nothing} = nothing
+    docker_build_stderr::Union{IO, Nothing} = nothing
 end
 
 """
-$(DocStringExtensions.TYPEDEF)
-
-## Fields:
-$(DocStringExtensions.TYPEDFIELDS )
+    DockerContainer()
 """
 Base.@kwdef struct DockerContainer
     label::String = Random.randstring(10)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,58 +1,79 @@
 using Docker
 using Test
 
-@testset "Docker.jl" begin
-    @testset "Test that Docker is installed" begin
-        @test success(`docker --version`)
-    end
+import Pkg
+import TOML
 
-    @testset "with_container()" begin
-        configs = [
-            DockerConfig(; image = "julia:latest", verbose = true),
-            DockerConfig(; image = "julia:latest", verbose = false),
-            DockerConfig(;
-                image = "julia:latest",
-                verbose = true,
-                stdout_docker_build = Base.devnull,
-                stderr_docker_build = Base.devnull,
-            ),
-        ]
-        for config in configs
-            with_container() do container
-                code = """
-                println("This was a success.")
-                """
-                @test success(container, config, `julia -e $(code)`)
+@testset "Ensure that there are no non-stdlib dependencies" begin
+    package_directories = String[
+        dirname(dirname(pathof(Docker))),
+        dirname(@__DIR__),
+        dirname(dirname(@__FILE__)),
+    ]
+    for package_directory in package_directories
+        package_project_filename = joinpath(package_directory, "Project.toml")
+        predictmd_project = TOML.parsefile(package_project_filename)
+        predictmd_direct_deps = predictmd_project["deps"]
+        for (name, uuid) in pairs(predictmd_direct_deps)
+            is_stdlib = Pkg.Types.is_stdlib(Base.UUID(uuid))
+            if !is_stdlib
+                @error("There is a non-stdlib dependency", name, uuid)
             end
-
-            with_container() do container
-                code = """
-                throw(ErrorException("This was a failure."))
-                """
-                @test !success(container, config, `julia -e $(code)`)
-            end
-
-            with_container() do container
-                code = """
-                println("This was a success.")
-                """
-                p = run(container, config, `julia -e $(code)`; wait = false)
-                wait(p)
-                @test success(p)
-            end
-
-            with_container() do container
-                code = """
-                throw(ErrorException("This was a failure."))
-                """
-                p = run(container, config, `julia -e $(code)`; wait = false)
-                wait(p)
-                @test !success(p)
-            end
+            @test is_stdlib
         end
     end
+end
 
-    @testset "Errors" begin
-        @test_throws ArgumentError Docker._generate_dockerfile(DockerConfig(; image = "foo", platform = :foo))
+@testset "Test that Docker is installed" begin
+    @test success(`docker --version`)
+end
+
+@testset "Errors" begin
+    @test_throws ArgumentError Docker._generate_dockerfile(DockerConfig(; image = "foo", platform = :foo))
+end
+
+@testset "with_container()" begin
+    configs = [
+        DockerConfig(; image = "julia:latest", verbose = true),
+        DockerConfig(; image = "julia:latest", verbose = false),
+        DockerConfig(;
+            image = "julia:latest",
+            verbose = true,
+            docker_build_stdout = Base.devnull,
+            docker_build_stderr = Base.devnull,
+        ),
+    ]
+    for config in configs
+        with_container() do container
+            code = """
+            println("This was a success.")
+            """
+            @test success(container, config, `julia -e $(code)`)
+        end
+
+        with_container() do container
+            code = """
+            throw(ErrorException("This was a failure."))
+            """
+            @test !success(container, config, `julia -e $(code)`)
+        end
+
+        with_container() do container
+            code = """
+            println("This was a success.")
+            """
+            p = run(container, config, `julia -e $(code)`; wait = false)
+            wait(p)
+            @test success(p)
+        end
+
+        with_container() do container
+            code = """
+            throw(ErrorException("This was a failure."))
+            """
+            p = run(container, config, `julia -e $(code)`; wait = false)
+            wait(p)
+            @test !success(p)
+        end
     end
 end


### PR DESCRIPTION
To increase security, let us make sure that we have no non-stdlib runtime dependencies.